### PR TITLE
Reworked validWebsiteURL to build a URI from the provided string url.…

### DIFF
--- a/src/main/java/org/wikivoyage/listings/validators/WebsiteURLValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/WebsiteURLValidator.java
@@ -3,6 +3,11 @@ package org.wikivoyage.listings.validators;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.wikivoyage.listings.entity.Listing;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
 public class WebsiteURLValidator implements Validator {
     @Override
     public String validate(Listing poi) {
@@ -18,9 +23,24 @@ public class WebsiteURLValidator implements Validator {
     public String getIssueType() {
         return "Website URL";
     }
-    
-    private boolean validWebsiteURL(String url) {
-        return UrlValidator.getInstance().isValid(url) &&
-            ( url.startsWith("http://") || url.startsWith("https://"));
+
+    private boolean validWebsiteURL(String urlString) {
+        try {
+            UrlValidator validator = new UrlValidator(new String[] {"https", "http"});
+            URL url = new URL(urlString);
+            URI uri = new URI(url.getProtocol()
+                    , url.getUserInfo()
+                    , url.getHost()
+                    , url.getPort()
+                    , url.getPath()
+                    , url.getQuery()
+                    , url.getRef()
+            );
+
+            return validator.isValid(uri.toASCIIString());
+
+        } catch (MalformedURLException | URISyntaxException e) {
+            return false;
+        }
     }
 }

--- a/src/test/java/org/wikivoyage/listings/ValidationTests.java
+++ b/src/test/java/org/wikivoyage/listings/ValidationTests.java
@@ -22,6 +22,7 @@ public class ValidationTests {
         assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.ville-douai.fr/index.php/Théâtre?idpage=14004")));
         assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.kitaena.co.jp/info/馬籠線.pdf")));
         assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.natuurenbos.be/nl-BE/Domeinen/Vlaams-Brabant/arborétum_Heverleebos.aspx")));
+        assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.some-url.de?q=glück")));
     }
 
     @Test
@@ -31,6 +32,7 @@ public class ValidationTests {
         assertNotNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://wikivoyage.org]")));
         assertNotNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("wikivoyage.org")));
         assertNotNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("mary@wikivoyage.org")));
+        assertNotNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("ftp://wikivoyage.org]")));
     }
     
     @Test


### PR DESCRIPTION
Related to #39.

Reworked WebsiteURLValidator#validWebsiteURL to build a URI from the provided string URL. This allows the newly constructed URI to be converted to an ASCII which will handle our encoding.

This resolves the issue where special characters (e.g accented characters would be flagged and logged as invalid URLs).