### PR TITLE
Additional Validations - URL and Lat-Long validation improvements

### DIFF
--- a/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
@@ -5,23 +5,26 @@ import org.wikivoyage.listings.entity.Listing;
 public class LatitudeValidator implements Validator {
     private final int MAX_LATITUDE = 90;
     private final String ERROR_PREFIX = "Malformed latitude";
+    private final String COORD_REGEX = "^(((\\d+(\\.\\d+)?)[^0-9.]*){3}[NESW])$";
 
     @Override
     public String validate(Listing poi) {
-
-        String errorMessage = String.format("%s '%s'", ERROR_PREFIX, poi.getLatitude());
+        boolean isValid = true;
 
         if (poi.getLatitude() != null && !poi.getLatitude().equals("")) {
             try {
                 Float coordinate = Float.parseFloat(poi.getLatitude());
                 if (Math.abs(coordinate) > MAX_LATITUDE) {
-                    return errorMessage;
+                    isValid = false;
                 }
             } catch (NumberFormatException e) {
-                return errorMessage;
+                if (!poi.getLatitude().matches(COORD_REGEX)) {
+                    isValid = false;
+                }
             }
         }
-        return null;
+
+        return isValid ? null : String.format("%s '%s'", ERROR_PREFIX, poi.getLatitude());
     }
 
     @Override

--- a/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
@@ -3,13 +3,22 @@ package org.wikivoyage.listings.validators;
 import org.wikivoyage.listings.entity.Listing;
 
 public class LatitudeValidator implements Validator {
+    private final int MAX_LATITUDE = 90;
+    private final String ERROR_PREFIX = "Malformed latitude";
+
     @Override
     public String validate(Listing poi) {
+
+        String errorMessage = String.format("%s '%s'", ERROR_PREFIX, poi.getLatitude());
+
         if (poi.getLatitude() != null && !poi.getLatitude().equals("")) {
             try {
-                Float.parseFloat(poi.getLatitude());
+                Float coordinate = Float.parseFloat(poi.getLatitude());
+                if (Math.abs(coordinate) > MAX_LATITUDE) {
+                    return errorMessage;
+                }
             } catch (NumberFormatException e) {
-                return "Malformed latitude '" + poi.getLatitude() + "'";
+                return errorMessage;
             }
         }
         return null;

--- a/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
@@ -3,13 +3,23 @@ package org.wikivoyage.listings.validators;
 import org.wikivoyage.listings.entity.Listing;
 
 public class LongitudeValidator implements Validator {
+    private final int MAX_LONGITUDE = 180;
+    private final String ERROR_PREFIX = "Malformed longitude";
+
     @Override
     public String validate(Listing poi) {
+
+        String errorMessage = String.format("%s '%s'", ERROR_PREFIX, poi.getLongitude());
+
         if (poi.getLongitude() != null && !poi.getLongitude().equals("")) {
             try {
-                Float.parseFloat(poi.getLongitude());
+                Float coordinate = Float.parseFloat(poi.getLongitude());
+                if (Math.abs(coordinate) > MAX_LONGITUDE) {
+                    return errorMessage;
+                }
+
             } catch (NumberFormatException e) {
-                return "Malformed longitude '" + poi.getLongitude() + "'";
+                return errorMessage;
             }
         }
         return null;

--- a/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
@@ -5,24 +5,26 @@ import org.wikivoyage.listings.entity.Listing;
 public class LongitudeValidator implements Validator {
     private final int MAX_LONGITUDE = 180;
     private final String ERROR_PREFIX = "Malformed longitude";
+    private final String COORD_REGEX = "^(((\\d+(\\.\\d+)?)[^0-9.]*){3}[NESW])$";
 
     @Override
     public String validate(Listing poi) {
-
-        String errorMessage = String.format("%s '%s'", ERROR_PREFIX, poi.getLongitude());
+        boolean isValid = true;
 
         if (poi.getLongitude() != null && !poi.getLongitude().equals("")) {
             try {
                 Float coordinate = Float.parseFloat(poi.getLongitude());
                 if (Math.abs(coordinate) > MAX_LONGITUDE) {
-                    return errorMessage;
+                    isValid = false;
                 }
-
             } catch (NumberFormatException e) {
-                return errorMessage;
+                if (!poi.getLongitude().matches(COORD_REGEX)) {
+                    isValid = false;
+                }
             }
         }
-        return null;
+
+        return isValid ? null : String.format("%s '%s'", ERROR_PREFIX, poi.getLongitude());
     }
 
     @Override

--- a/src/main/java/org/wikivoyage/listings/validators/WebsiteURLValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/WebsiteURLValidator.java
@@ -3,10 +3,7 @@ package org.wikivoyage.listings.validators;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.wikivoyage.listings.entity.Listing;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.*;
 
 public class WebsiteURLValidator implements Validator {
     @Override
@@ -30,7 +27,7 @@ public class WebsiteURLValidator implements Validator {
             URL url = new URL(urlString);
             URI uri = new URI(url.getProtocol()
                     , url.getUserInfo()
-                    , url.getHost()
+                    , IDN.toASCII(url.getHost())
                     , url.getPort()
                     , url.getPath()
                     , url.getQuery()

--- a/src/test/java/org/wikivoyage/listings/ValidationTests.java
+++ b/src/test/java/org/wikivoyage/listings/ValidationTests.java
@@ -21,6 +21,7 @@ public class ValidationTests {
         assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.kitaena.co.jp/info/馬籠線.pdf")));
         assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.natuurenbos.be/nl-BE/Domeinen/Vlaams-Brabant/arborétum_Heverleebos.aspx")));
         assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.some-url.de?q=glück")));
+        assertNull(new WebsiteURLValidator().validate(TestWikivoyagePOI.createWithURL("http://www.countrylokal-goldgräber.de/")));
     }
 
     @Test

--- a/src/test/java/org/wikivoyage/listings/ValidationTests.java
+++ b/src/test/java/org/wikivoyage/listings/ValidationTests.java
@@ -61,6 +61,7 @@ public class ValidationTests {
 
         assertNull(validator.validate(TestWikivoyagePOI.createWithLatitude("")));
         assertNull(validator.validate(TestWikivoyagePOI.createWithLatitude("57.058889")));
+        assertNull(validator.validate(TestWikivoyagePOI.createWithLatitude("41°55'49.4\"N")));
     }
 
     @Test
@@ -79,6 +80,7 @@ public class ValidationTests {
         assertNull(validator.validate(TestWikivoyagePOI.createWithLongitude("")));
         assertNull(validator.validate(TestWikivoyagePOI.createWithLongitude("-9.920728")));
         assertNull(validator.validate(TestWikivoyagePOI.createWithLongitude("179.920728")));
+        assertNull(validator.validate(TestWikivoyagePOI.createWithLongitude("17°38'15.60\"E")));
     }
 
     @Test
@@ -88,6 +90,7 @@ public class ValidationTests {
         assertNotNull(validator.validate(TestWikivoyagePOI.createWithLongitude("-181.23")));
         assertNotNull(validator.validate(TestWikivoyagePOI.createWithLongitude("-180.00005")));
         assertNotNull(validator.validate(TestWikivoyagePOI.createWithLongitude("not a longitude")));
+        assertNotNull(validator.validate(TestWikivoyagePOI.createWithLongitude("123,345,567")));
     }
 }
 

--- a/src/test/java/org/wikivoyage/listings/ValidationTests.java
+++ b/src/test/java/org/wikivoyage/listings/ValidationTests.java
@@ -5,9 +5,7 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.wikivoyage.listings.entity.Listing;
-import org.wikivoyage.listings.validators.EmailValidator;
-import org.wikivoyage.listings.validators.WebsiteURLValidator;
-import org.wikivoyage.listings.validators.WikidataValidator;
+import org.wikivoyage.listings.validators.*;
 
 public class ValidationTests {
     
@@ -56,6 +54,41 @@ public class ValidationTests {
         assertNotNull(new WikidataValidator().validate(TestWikivoyagePOI.createWithWikidata("QID42")));
         assertNotNull(new WikidataValidator().validate(TestWikivoyagePOI.createWithWikidata("q42")));
     }
+
+    @Test
+    public void validLatitudeTests() {
+        LatitudeValidator validator = new LatitudeValidator();
+
+        assertNull(validator.validate(TestWikivoyagePOI.createWithLatitude("")));
+        assertNull(validator.validate(TestWikivoyagePOI.createWithLatitude("57.058889")));
+    }
+
+    @Test
+    public void invalidLatitudeTests() {
+        LatitudeValidator validator = new LatitudeValidator();
+
+        assertNotNull(validator.validate(TestWikivoyagePOI.createWithLatitude("-90.1")));
+        assertNotNull(validator.validate(TestWikivoyagePOI.createWithLatitude("not a coordinate")));
+        assertNotNull(validator.validate(TestWikivoyagePOI.createWithLatitude("90.005")));
+    }
+
+    @Test
+    public void validLongitudeTests() {
+        LongitudeValidator validator = new LongitudeValidator();
+
+        assertNull(validator.validate(TestWikivoyagePOI.createWithLongitude("")));
+        assertNull(validator.validate(TestWikivoyagePOI.createWithLongitude("-9.920728")));
+        assertNull(validator.validate(TestWikivoyagePOI.createWithLongitude("179.920728")));
+    }
+
+    @Test
+    public void invalidLongitudeTests() {
+        LongitudeValidator validator = new LongitudeValidator();
+
+        assertNotNull(validator.validate(TestWikivoyagePOI.createWithLongitude("-181.23")));
+        assertNotNull(validator.validate(TestWikivoyagePOI.createWithLongitude("-180.00005")));
+        assertNotNull(validator.validate(TestWikivoyagePOI.createWithLongitude("not a longitude")));
+    }
 }
 
 /**
@@ -67,6 +100,18 @@ class TestWikivoyagePOI extends Listing {
         super ("", "", "", "", "", "", "", "", "", "",
                 "", "", "", "", "","", "", "", "", "",
                 "", "", "", "", "");
+    }
+
+    public static TestWikivoyagePOI createWithLongitude(String longitude) {
+        TestWikivoyagePOI poi = new TestWikivoyagePOI();
+        poi.longitude = longitude;
+        return poi;
+    }
+
+    public static TestWikivoyagePOI createWithLatitude(String latitude) {
+        TestWikivoyagePOI poi = new TestWikivoyagePOI();
+        poi.latitude = latitude;
+        return poi;
     }
     
     public static TestWikivoyagePOI createWithEmail(String email) {


### PR DESCRIPTION
A few updates have been made to the validations. 
1. I noticed that some URLs which were working, were still not valid. This was caused by non standard characters appearing in the host name which breaks with the RFC2396 which java.net.URL uses.
2. Related to #41 , I have added some validation checks on both decimal and DMS (e.g. 17°38'15.60"E) style coordinates. The DMS style coordinates are validated when the input is not a float value and conforms to a regex which I have defined. The regex is probably not flawless but covers all cases which I threw at it as well as not letting extra stuff through. 