### PR TITLE
Change German Wikidata property name, fixes #44

### DIFF
--- a/src/main/java/org/wikivoyage/listings/language/german/German.java
+++ b/src/main/java/org/wikivoyage/listings/language/german/German.java
@@ -143,7 +143,7 @@ public class German implements Language
 			poiType,
 			template.getArgument("name"),
 			template.getArgument("alt"),
-            template.getArgument("d"), // Wikidata
+            template.getArgument("wikidata"), // Wikidata
             "", // No Wikipedia property on German Wikivoyage
 			template.getArgument("address"),
 			template.getArgument("directions"),


### PR DESCRIPTION
Changed German Wikidata property name from "d" to "wikidata".