### PR TITLE
Improved latitude and longitude validation, and fixed help function

### DIFF
--- a/src/main/java/org/wikivoyage/listings/Main.java
+++ b/src/main/java/org/wikivoyage/listings/Main.java
@@ -62,7 +62,7 @@ public class Main {
 
         try {
             if (cl.help) {
-                cl.printHelp((String[])formats.keySet().toArray());
+                cl.printHelp(formatNames);
             } else if (cl.dailyUpdate) {
                 dailyUpdate(cl, formats);
             } else {

--- a/src/main/java/org/wikivoyage/listings/validators/GeographicPositionValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/GeographicPositionValidator.java
@@ -1,0 +1,50 @@
+package org.wikivoyage.listings.validators;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.wikivoyage.listings.entity.Listing;
+
+/**
+ * General superclass for longitude/latitude to reduce code proliferation.
+ */
+public abstract class GeographicPositionValidator extends SimpleValidator {
+  	
+	//Declare statically so we compile this once
+	private static Pattern INVALID_CHARS_FOR_GEOGRAPHIC_POSITION = Pattern.compile("[^0-9.-]");
+	
+	protected abstract int getMinValue();
+    protected abstract int getMaxValue();
+    protected abstract ValidationIssue getValidationIssue();
+    protected abstract String getGeographicPositionValue(Listing poi);
+    
+      @Override
+      public void validate(Listing poi) {
+      	String geographicPosition = getGeographicPositionValue(poi);
+      	if (StringUtils.isEmpty(geographicPosition)) {
+      		//Do nothing; not invalid but no point parsing
+      		return;
+      	}
+      	
+      	//Detect invalid chars in the position. Not trying to fix, just flag as invalid.
+      	// This is more robust than just relying on the NFE because we explicitly know what these SHOULD contain.
+      	Matcher m = INVALID_CHARS_FOR_GEOGRAPHIC_POSITION.matcher(geographicPosition);
+      	if (m.find()) {
+          	poi.add(getValidationIssue());
+          }
+          else {
+          	//Otherwise try to parse this as valid.
+              try {
+                  float geographicPositionF = Float.parseFloat(geographicPosition);
+                  //There are fixed values for these positions. Outside these, it's invalid.
+                  if (geographicPositionF < getMinValue() || geographicPositionF > getMaxValue()) {
+                  	poi.add(getValidationIssue());
+                  }
+              } catch (NumberFormatException e) {
+              	//This is now an unexpected case, seeing as we've removed all non-numeric chars.
+                  poi.add(getValidationIssue());
+              }
+          }
+      }
+}

--- a/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
@@ -1,40 +1,30 @@
 package org.wikivoyage.listings.validators;
 
-import org.apache.commons.lang.StringUtils;
 import org.wikivoyage.listings.entity.Listing;
 
-public class LatitudeValidator extends SimpleValidator {
+public final class LatitudeValidator extends GeographicPositionValidator {
 	
 	//0 at the equator; 90 at the respective poles
 	private static final int MIN_LATITUDE = -90;
 	private static final int MAX_LATITUDE = 90;
-	
-    @Override
-    public void validate(Listing poi) {
-    	String latitude = poi.getLatitude();
-    	if (StringUtils.isEmpty(latitude)) {
-    		//Do nothing; not invalid but no point parsing
-    		return;
-    	}
-    	
-    	//Sanitise the latitude to see if it contained invalid chars. Not trying to fix, just flag as invalid.
-    	// This is more robust than just relying on the NFE because we explicitly know what a latitude SHOULD contain.
-    	String sanitisedLatitude = latitude.replaceAll("[^0-9.-]","");
-    	if (!sanitisedLatitude.equals(latitude)) {
-        	poi.add(ValidationIssue.INVALID_LATITUDE);
-        }
-        else {
-        	//Otherwise try to parse this as a valid latitude.
-            try {
-                float latitudeF = Float.parseFloat(latitude);
-                //There are fixed values for latitude. Outside these, it's invalid.
-                if (latitudeF < MIN_LATITUDE || latitudeF > MAX_LATITUDE) {
-                	poi.add(ValidationIssue.INVALID_LATITUDE);
-                }
-            } catch (NumberFormatException e) {
-            	//This is now an unexpected case, seeing as we've removed all non-numeric chars.
-                poi.add(ValidationIssue.INVALID_LATITUDE);
-            }
-        }
-    }
+
+	@Override
+	protected int getMinValue() {
+		return MIN_LATITUDE;
+	}
+
+	@Override
+	protected int getMaxValue() {
+		return MAX_LATITUDE;
+	}
+
+	@Override
+	protected ValidationIssue getValidationIssue() {
+		return ValidationIssue.INVALID_LATITUDE;
+	}
+
+	@Override
+	protected String getGeographicPositionValue(Listing poi) {
+		return poi.getLatitude();
+	}
 }

--- a/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LatitudeValidator.java
@@ -1,14 +1,38 @@
 package org.wikivoyage.listings.validators;
 
+import org.apache.commons.lang.StringUtils;
 import org.wikivoyage.listings.entity.Listing;
 
 public class LatitudeValidator extends SimpleValidator {
+	
+	//0 at the equator; 90 at the respective poles
+	private static final int MIN_LATITUDE = -90;
+	private static final int MAX_LATITUDE = 90;
+	
     @Override
     public void validate(Listing poi) {
-        if (poi.getLatitude() != null && !poi.getLatitude().equals("")) {
+    	String latitude = poi.getLatitude();
+    	if (StringUtils.isEmpty(latitude)) {
+    		//Do nothing; not invalid but no point parsing
+    		return;
+    	}
+    	
+    	//Sanitise the latitude to see if it contained invalid chars. Not trying to fix, just flag as invalid.
+    	// This is more robust than just relying on the NFE because we explicitly know what a latitude SHOULD contain.
+    	String sanitisedLatitude = latitude.replaceAll("[^0-9.-]","");
+    	if (!sanitisedLatitude.equals(latitude)) {
+        	poi.add(ValidationIssue.INVALID_LATITUDE);
+        }
+        else {
+        	//Otherwise try to parse this as a valid latitude.
             try {
-                Float.parseFloat(poi.getLatitude());
+                float latitudeF = Float.parseFloat(latitude);
+                //There are fixed values for latitude. Outside these, it's invalid.
+                if (latitudeF < MIN_LATITUDE || latitudeF > MAX_LATITUDE) {
+                	poi.add(ValidationIssue.INVALID_LATITUDE);
+                }
             } catch (NumberFormatException e) {
+            	//This is now an unexpected case, seeing as we've removed all non-numeric chars.
                 poi.add(ValidationIssue.INVALID_LATITUDE);
             }
         }

--- a/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
@@ -1,16 +1,40 @@
 package org.wikivoyage.listings.validators;
 
+import org.apache.commons.lang.StringUtils;
 import org.wikivoyage.listings.entity.Listing;
 
 public class LongitudeValidator extends SimpleValidator {
-    @Override
-    public void validate(Listing poi) {
-        if (poi.getLongitude() != null && !poi.getLongitude().equals("")) {
-            try {
-                Float.parseFloat(poi.getLongitude());
-            } catch (NumberFormatException e) {
-                poi.add(ValidationIssue.INVALID_LONGITUDE);
-            }
-        }
-    }
+    
+	//0 at the prime meridian; 180 degrees east and west
+  	private static final int MIN_LONGITUDE = -180;
+  	private static final int MAX_LONGITUDE = 180;
+  	
+      @Override
+      public void validate(Listing poi) {
+      	String longitude = poi.getLongitude();
+      	if (StringUtils.isEmpty(longitude)) {
+      		//Do nothing; not invalid but no point parsing
+      		return;
+      	}
+      	
+      	//Sanitise the longitude to see if it contained invalid chars. Not trying to fix, just flag as invalid.
+      	// This is more robust than just relying on the NFE because we explicitly know what a longitude SHOULD contain.
+      	String sanitisedLongitude = longitude.replaceAll("[^0-9.-]","");
+      	if (!sanitisedLongitude.equals(longitude)) {
+          	poi.add(ValidationIssue.INVALID_LONGITUDE);
+          }
+          else {
+          	//Otherwise try to parse this as a valid longitude.
+              try {
+                  float latitudeF = Float.parseFloat(longitude);
+                  //There are fixed values for longitude. Outside these, it's invalid.
+                  if (latitudeF < MIN_LONGITUDE || latitudeF > MAX_LONGITUDE) {
+                  	poi.add(ValidationIssue.INVALID_LONGITUDE);
+                  }
+              } catch (NumberFormatException e) {
+              	//This is now an unexpected case, seeing as we've removed all non-numeric chars.
+                  poi.add(ValidationIssue.INVALID_LONGITUDE);
+              }
+          }
+      }
 }

--- a/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
@@ -26,9 +26,9 @@ public class LongitudeValidator extends SimpleValidator {
           else {
           	//Otherwise try to parse this as a valid longitude.
               try {
-                  float latitudeF = Float.parseFloat(longitude);
+                  float longitudeF = Float.parseFloat(longitude);
                   //There are fixed values for longitude. Outside these, it's invalid.
-                  if (latitudeF < MIN_LONGITUDE || latitudeF > MAX_LONGITUDE) {
+                  if (longitudeF < MIN_LONGITUDE || longitudeF > MAX_LONGITUDE) {
                   	poi.add(ValidationIssue.INVALID_LONGITUDE);
                   }
               } catch (NumberFormatException e) {

--- a/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
+++ b/src/main/java/org/wikivoyage/listings/validators/LongitudeValidator.java
@@ -1,40 +1,30 @@
 package org.wikivoyage.listings.validators;
 
-import org.apache.commons.lang.StringUtils;
 import org.wikivoyage.listings.entity.Listing;
 
-public class LongitudeValidator extends SimpleValidator {
+public class LongitudeValidator extends GeographicPositionValidator {
     
 	//0 at the prime meridian; 180 degrees east and west
   	private static final int MIN_LONGITUDE = -180;
   	private static final int MAX_LONGITUDE = 180;
-  	
-      @Override
-      public void validate(Listing poi) {
-      	String longitude = poi.getLongitude();
-      	if (StringUtils.isEmpty(longitude)) {
-      		//Do nothing; not invalid but no point parsing
-      		return;
-      	}
-      	
-      	//Sanitise the longitude to see if it contained invalid chars. Not trying to fix, just flag as invalid.
-      	// This is more robust than just relying on the NFE because we explicitly know what a longitude SHOULD contain.
-      	String sanitisedLongitude = longitude.replaceAll("[^0-9.-]","");
-      	if (!sanitisedLongitude.equals(longitude)) {
-          	poi.add(ValidationIssue.INVALID_LONGITUDE);
-          }
-          else {
-          	//Otherwise try to parse this as a valid longitude.
-              try {
-                  float longitudeF = Float.parseFloat(longitude);
-                  //There are fixed values for longitude. Outside these, it's invalid.
-                  if (longitudeF < MIN_LONGITUDE || longitudeF > MAX_LONGITUDE) {
-                  	poi.add(ValidationIssue.INVALID_LONGITUDE);
-                  }
-              } catch (NumberFormatException e) {
-              	//This is now an unexpected case, seeing as we've removed all non-numeric chars.
-                  poi.add(ValidationIssue.INVALID_LONGITUDE);
-              }
-          }
-      }
+
+	@Override
+	protected int getMinValue() {
+		return MIN_LONGITUDE;
+	}
+
+	@Override
+	protected int getMaxValue() {
+		return MAX_LONGITUDE;
+	}
+
+	@Override
+	protected ValidationIssue getValidationIssue() {
+		return ValidationIssue.INVALID_LONGITUDE;
+	}
+
+	@Override
+	protected String getGeographicPositionValue(Listing poi) {
+		return poi.getLongitude();
+	}
 }

--- a/src/test/java/org/wikivoyage/listings/ValidationTests.java
+++ b/src/test/java/org/wikivoyage/listings/ValidationTests.java
@@ -9,6 +9,8 @@ import java.util.Iterator;
 import org.junit.Test;
 import org.wikivoyage.listings.entity.Listing;
 import org.wikivoyage.listings.validators.EmailValidator;
+import org.wikivoyage.listings.validators.LatitudeValidator;
+import org.wikivoyage.listings.validators.LongitudeValidator;
 import org.wikivoyage.listings.validators.WebsiteURLValidator;
 import org.wikivoyage.listings.validators.WikidataValidator;
 
@@ -98,6 +100,71 @@ public class ValidationTests {
         assertFalse(validationIterator.next().isValid());
         assertFalse(validationIterator.next().isValid());
     }
+    
+    /**
+     * A valid latitude is a decimal value between -90 and 90
+     */
+    @Test
+    public void testLatitude() {
+    	
+    	//Valid cases
+    	Listing p1 = TestWikivoyagePOI.createWithLatitude(null);
+    	Listing p2 = TestWikivoyagePOI.createWithLatitude("");
+    	Listing p3 = TestWikivoyagePOI.createWithLatitude("90.00000");
+    	Listing p4 = TestWikivoyagePOI.createWithLatitude("-90.00000");
+    	
+    	//Invalid cases
+    	//Five decimal places is the maximum reasonable degree of accuracy in this context, so using that for edge case testing
+    	// Source: https://gis.stackexchange.com/a/8674
+    	Listing p5 = TestWikivoyagePOI.createWithLatitude("-90.00001");
+    	Listing p6 = TestWikivoyagePOI.createWithLatitude("90.00001");
+    	Listing p7 = TestWikivoyagePOI.createWithLatitude("66'34 N");
+    	
+    	
+    	Iterator<Listing> validationIterator = 
+                new LatitudeValidator().validate(Arrays.asList(p1, p2, p3, p4, p5, p6, p7)).iterator();
+    	
+    	assertTrue(validationIterator.next().isValid()); //Null is fine
+    	assertTrue(validationIterator.next().isValid()); //Empty string is fine
+    	assertTrue(validationIterator.next().isValid()); //Edge case, upper bound
+    	assertTrue(validationIterator.next().isValid()); //Edge case, lower bound
+    	
+        assertFalse(validationIterator.next().isValid()); //Edge case, over upper bound
+        assertFalse(validationIterator.next().isValid()); //Edge case, under lower bound
+        assertFalse(validationIterator.next().isValid()); //Non-decimal latitude
+    }
+    
+    /**
+     * A valid longitude is a decimal value between -180 and 180
+     */
+    @Test
+    public void testLongitude() {
+    	
+    	//Valid cases
+    	Listing p1 = TestWikivoyagePOI.createWithLongitude(null);
+    	Listing p2 = TestWikivoyagePOI.createWithLongitude("");
+    	Listing p3 = TestWikivoyagePOI.createWithLongitude("180.00000");
+    	Listing p4 = TestWikivoyagePOI.createWithLongitude("-180.00000");
+    	
+    	//Invalid cases
+    	//Five decimal places is the maximum reasonable degree of accuracy in this context, so using that for edge case testing
+    	// Source: https://gis.stackexchange.com/a/8674
+    	Listing p5 = TestWikivoyagePOI.createWithLongitude("-180.00001");
+    	Listing p6 = TestWikivoyagePOI.createWithLongitude("180.00001");
+    	Listing p7 = TestWikivoyagePOI.createWithLongitude("66'34 E");    	
+    	
+    	Iterator<Listing> validationIterator = 
+                new LongitudeValidator().validate(Arrays.asList(p1, p2, p3, p4, p5, p6, p7)).iterator();
+    	
+    	assertTrue(validationIterator.next().isValid()); //Null is fine
+    	assertTrue(validationIterator.next().isValid()); //Empty string is fine
+    	assertTrue(validationIterator.next().isValid()); //Edge case, upper bound
+    	assertTrue(validationIterator.next().isValid()); //Edge case, lower bound
+    	
+        assertFalse(validationIterator.next().isValid()); //Edge case, over upper bound
+        assertFalse(validationIterator.next().isValid()); //Edge case, under lower bound
+        assertFalse(validationIterator.next().isValid()); //Non-decimal longitude
+    }
 }
 
 /**
@@ -126,6 +193,18 @@ class TestWikivoyagePOI extends Listing {
     public static TestWikivoyagePOI createWithURL(String url) {
         TestWikivoyagePOI poi = new TestWikivoyagePOI();
         poi.url = url;
+        return poi;
+    }
+    
+    public static TestWikivoyagePOI createWithLatitude(String latitude) {
+        TestWikivoyagePOI poi = new TestWikivoyagePOI();
+        poi.latitude = latitude;
+        return poi;
+    }
+    
+    public static TestWikivoyagePOI createWithLongitude(String longitude) {
+        TestWikivoyagePOI poi = new TestWikivoyagePOI();
+        poi.longitude = longitude;
         return poi;
     }
 }


### PR DESCRIPTION
For issue #75 

Two changes:
1. Fixed a ClassCastException when calling main -help
2. Improved latitude and longitude validators based on data.world feedback report:
   a. More robust handling of non-decimal values
   b. Added validation to eliminate invalid decimal values (i.e. longitudes over/under 180/-180)
   c. Added validation tests for latitudes and longitudes. 